### PR TITLE
Removed docstub from posts. Their site doesn't use react

### DIFF
--- a/_posts/2016-6-6-docstub.md
+++ b/_posts/2016-6-6-docstub.md
@@ -1,8 +1,0 @@
----
-layout: post
-title: DocsTub
-slug: docstub
-source: https://docstub.com
----
-
-<img src="/screenshots/docstub.png" alt="DocsTub">


### PR DESCRIPTION
Removing DocStub from the list. They appear not to be using React.

Closes #38 