### PR TITLE
Added test service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,8 @@ services:
       - "4000:4000"
     volumes:
       - .:/built-with-react
+  test:
+    build: .
+    volumes:
+      - .:/built-with-react
+    command: bash script/cibuild


### PR DESCRIPTION
Thought it might be good to be able to run the `cibuild` script with docker-compose as a "test service".

@gcollazo any thoughts?